### PR TITLE
Headers should be separated by CR & LF

### DIFF
--- a/web.el
+++ b/web.el
@@ -279,7 +279,7 @@ Keys may be symbols or strings."
   "Convert HEADERS (hash-table or alist) into a header list."
   (labels
       ((hdr (key val)
-         (format "%s: %s" key val)))
+         (format "%s: %s\r\n" key val)))
     (cond
       ((hash-table-p headers)
        (let (res)


### PR DESCRIPTION
In the `web/header-list` function, the headers need to be separated by CR & LF else majority of the web servers (tested with elnode and python's wsgiref) tend to hang waiting for the completion of request.

As per wikipedia from the second paragraph of https://en.wikipedia.org/wiki/List_of_HTTP_header_fields

"""
The header fields are transmitted after the request or response line, the first line of a message. Header fields are colon-separated name-value pairs in clear-text string format, terminated by a carriage return (CR) and line feed (LF) character sequence. The end of the header fields is indicated by an empty field, resulting in the transmission of two consecutive CR-LF pairs. Long lines can be folded into multiple lines; continuation lines are indicated by presence of space (SP) or horizontal tab (HT) as first character on next line.[1] Few fields can also contain comments (i.e. in. User-Agent, Server, Via fields), which can be ignored by software.[2]
"""

I have enclosed a test (first commit) which on running without the fix (second commit) will have the elnode server waiting indefinitely. After applying the fix, the tests run fine and the server responds.
