### PR TITLE
re-require cl

### DIFF
--- a/web.el
+++ b/web.el
@@ -59,7 +59,8 @@
 ;;
 ;; for private functions.
 
-
+(eval-when-compile
+  (require 'cl))
 (require 'cl-lib)
 (require 'url-parse)
 (require 'json)


### PR DESCRIPTION
restored lines 

```
(eval-when-compile 
  (require 'cl))
```

to fix (invalid-function assert) error when calling web-http-post
