### PR TITLE
Set correct Content-length value for non-ascii charaters.

### DIFF
--- a/web.el
+++ b/web.el
@@ -487,7 +487,7 @@ set on the Content-Type header."
          http-hdrs)))
     (when (and to-send (> (length to-send) 0))
       (push
-       (format "Content-length: %d\r\n" (length to-send))
+       (format "Content-length: %d\r\n" (string-bytes to-send))
        http-hdrs))
     (cl-loop for hdr in http-hdrs if hdr concat hdr)))
 


### PR DESCRIPTION
According to the HTTP 1.1 standard, this value must match the number of bytes being transfered. (length to-send) evaluates to the number of characters of the string, not the total bytes of the content.

https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html

4.4 Message Length

<pre>
When a Content-Length is given in a message where a message-body is allowed, its field value MUST exactly match the number of OCTETs in the message-body. HTTP/1.1 user agents MUST notify the user when an invalid length is received and detected. 
</pre>